### PR TITLE
Tracing - improved tracing for Networking.UDPMessageHandler

### DIFF
--- a/Networking/ReferenceApplication/AppBootstrapper.cs
+++ b/Networking/ReferenceApplication/AppBootstrapper.cs
@@ -22,8 +22,6 @@ namespace UAOOI.Networking.ReferenceApplication
     public override void Run(bool runWithDefaultConfiguration)
     {
       base.Run(runWithDefaultConfiguration);
-      m_ConsumerConfigurationFactory.Setup();
-      m_OPCUAServerProducerSimulator.Setup();
     }
     protected override void ConfigureContainer()
     {
@@ -39,8 +37,6 @@ namespace UAOOI.Networking.ReferenceApplication
       base.InitializeShell();
       Application.Current.MainWindow = (MainWindow)this.Shell;
       Application.Current.MainWindow.Show();
-      m_ConsumerConfigurationFactory = Container.GetExportedValue<ConsumerDataManagementSetup>();
-      m_OPCUAServerProducerSimulator = Container.GetExportedValue<OPCUAServerProducerSimulator>(); 
     }
     /// <summary>
     /// Creates the shell or main window of the application.
@@ -54,6 +50,14 @@ namespace UAOOI.Networking.ReferenceApplication
     protected override DependencyObject CreateShell()
     {
       return this.Container.GetExportedValue<MainWindow>();
+    }
+    protected override void OnInitialized()
+    {
+      base.OnInitialized();
+      m_ConsumerConfigurationFactory = Container.GetExportedValue<ConsumerDataManagementSetup>();
+      m_OPCUAServerProducerSimulator = Container.GetExportedValue<OPCUAServerProducerSimulator>();
+      m_ConsumerConfigurationFactory.Setup();
+      m_OPCUAServerProducerSimulator.Setup();
     }
     #endregion
 

--- a/Networking/ReferenceApplication/Consumer/ConsumerDataManagementSetup.cs
+++ b/Networking/ReferenceApplication/Consumer/ConsumerDataManagementSetup.cs
@@ -1,8 +1,13 @@
 ﻿
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics.Tracing;
+using System.Reactive;
 using System.Windows.Input;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks;
 using UAOOI.Networking.SemanticData;
+using UAOOI.Networking.SemanticData.Diagnostics;
 //using UAOOI.Networking.UDPMessageHandler;
 
 namespace UAOOI.Networking.ReferenceApplication.Consumer
@@ -28,11 +33,18 @@ namespace UAOOI.Networking.ReferenceApplication.Consumer
         ViewModel.Trace("Entering Setup");
         ViewModel.ConsumerUpdateConfiguration = new RestartCommand(Restart);
         ConfigurationFactory = new ConsumerConfigurationFactory();
-        //MessageHandlerFactory = new MessageHandlerFactory();
         MainWindowModel _model = new MainWindowModel() { ViewModelBindingFactory = ViewModel };
         BindingFactory = _model;
         EncodingFactory = _model;
         ViewModel.Trace("Initialize consumer engine and start receiving UDP frames.");
+        INetworkingEventSourceProvider _sourceProvider = MessageHandlerFactory as INetworkingEventSourceProvider;
+        if (_sourceProvider != null)
+        {
+          m_Subscription = SinkExtensions.CreateSink(x => ViewModel.Trace(x.FormattedMessage));
+          m_Subscription.Sink.EnableEvents(_sourceProvider.GetPartEventSource(), EventLevel.LogAlways, Keywords.All);
+          m_FileSubscription = SinkExtensions.CreateSink(_sourceProvider.GetPartEventSource(), "ReferenceApplication.log");
+          //m_FileSubscription.Sink.EnableEvents(_sourceProvider.GetPartEventSource(), EventLevel.LogAlways, Keywords.All);
+        }
         Start();
         ViewModel.ConsumerErrorMessage = "Running";
       }
@@ -67,12 +79,51 @@ namespace UAOOI.Networking.ReferenceApplication.Consumer
       }
       private Action m_restart;
     }
+    private SinkSubscription<ObservableEventListener> m_Subscription;
+    private SinkSubscription<FlatFileSink> m_FileSubscription;
+    private bool m_Disposed = false;
+
     private void Restart()
     {
       ViewModel.Trace("Entering Restart");
       Start();
     }
     #endregion
+    protected override void Dispose(bool disposing)
+    {
+      base.Dispose(disposing);
+      if (!disposing || m_Disposed)
+        return;
+      m_Subscription?.Dispose();
+      m_Subscription = null;
+      m_FileSubscription?.Sink.FlushAsync();
+      m_FileSubscription?.Dispose();
+      m_FileSubscription = null;
+    }
+  }
+  public static class SinkExtensions
+  {
+
+    public static SinkSubscription<ObservableEventListener> CreateSink(this ObservableEventListener eventStream, Action<EventEntry> feedback)
+    {
+      IDisposable subscription = eventStream.Subscribe(feedback);
+      return new SinkSubscription<ObservableEventListener>(subscription, eventStream);
+    }
+
+    public static SinkSubscription<ObservableEventListener> CreateSink(Action<EventEntry> feedback)
+    {
+      ObservableEventListener _listener = new ObservableEventListener();
+      IDisposable subscription = _listener.Subscribe(feedback);
+      return new SinkSubscription<ObservableEventListener>(subscription, _listener);
+    }
+    public static SinkSubscription<FlatFileSink> CreateSink(EventSource eventSource, string path)
+    {
+      ObservableEventListener _listener = new ObservableEventListener();
+      _listener.EnableEvents(eventSource, EventLevel.LogAlways, Keywords.All);
+      return _listener.LogToFlatFile(path);
+    }
 
   }
 }
+
+

--- a/Networking/ReferenceApplication/Consumer/IConsumerViewModel.cs
+++ b/Networking/ReferenceApplication/Consumer/IConsumerViewModel.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 using UAOOI.Networking.SemanticData.DataRepository;
 using UAOOI.Configuration.Networking.Serialization;
 
-namespace UAOOI.Networking.ReferenceApplication
+namespace UAOOI.Networking.ReferenceApplication.Consumer
 {
   internal interface IConsumerViewModel
   {

--- a/Networking/ReferenceApplication/MainWindowViewModel.cs
+++ b/Networking/ReferenceApplication/MainWindowViewModel.cs
@@ -5,12 +5,13 @@ using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
-using System.Net;
 using System.Reflection;
 using System.Windows;
 using System.Windows.Input;
 using UAOOI.Configuration.Networking.Serialization;
+using UAOOI.Networking.ReferenceApplication.Consumer;
 using UAOOI.Networking.ReferenceApplication.Controls;
+using UAOOI.Networking.ReferenceApplication.Producer;
 using UAOOI.Networking.SemanticData.DataRepository;
 
 namespace UAOOI.Networking.ReferenceApplication

--- a/Networking/ReferenceApplication/Networking.ReferenceApplication.csproj
+++ b/Networking/ReferenceApplication/Networking.ReferenceApplication.csproj
@@ -85,9 +85,24 @@
       <HintPath>..\..\packages\MvvmLightLibs.5.3.0.0\lib\net45\GalaSoft.MvvmLight.Platform.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.2.0.1406.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.TextFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EnterpriseLibrary.SemanticLogging.TextFile.2.0.1406.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.TextFile.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\MvvmLightLibs.5.3.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
@@ -140,8 +155,8 @@
     <Compile Include="Consumer\ConsumerConfigurationFactory.cs" />
     <Compile Include="Consumer\ConsumerDataManagementSetup.cs" />
     <Compile Include="Consumer\MainWindowModel.cs" />
-    <Compile Include="IConsumerViewModel.cs" />
-    <Compile Include="IProducerViewModel.cs" />
+    <Compile Include="Consumer\IConsumerViewModel.cs" />
+    <Compile Include="Producer\IProducerViewModel.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Networking/ReferenceApplication/Producer/IProducerViewModel.cs
+++ b/Networking/ReferenceApplication/Producer/IProducerViewModel.cs
@@ -1,7 +1,7 @@
 ﻿
 using System.Windows.Input;
 
-namespace UAOOI.Networking.ReferenceApplication
+namespace UAOOI.Networking.ReferenceApplication.Producer
 {
   internal interface IProducerViewModel
   {

--- a/Networking/ReferenceApplication/packages.config
+++ b/Networking/ReferenceApplication/packages.config
@@ -2,6 +2,11 @@
 <packages>
   <package id="CAS.UA.IServerConfiguration" version="1.00.00" targetFramework="net461" />
   <package id="CommonServiceLocator" version="2.0.1" targetFramework="net461" />
+  <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net461" />
+  <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net461" />
   <package id="Microsoft.DependencyValidation.Analyzers" version="0.9.0" targetFramework="net461" />
   <package id="MvvmLightLibs" version="5.3.0.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net461" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net461" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net461" />
 </packages>

--- a/Networking/SemanticData/Diagnostics/INetworkingEventSourceProvider.cs
+++ b/Networking/SemanticData/Diagnostics/INetworkingEventSourceProvider.cs
@@ -1,0 +1,20 @@
+﻿
+using System.Diagnostics.Tracing;
+
+namespace UAOOI.Networking.SemanticData.Diagnostics
+{
+  /// <summary>
+  /// Interface IEventSourceProvider - if implemented returns an instance of <see cref="EventSource"/> to be registered by the logging infrastructure.
+  /// </summary>
+  public interface INetworkingEventSourceProvider
+  {
+
+    /// <summary>
+    /// Gets the part event source.
+    /// </summary>
+    /// <returns>An instance of <see cref="EventSource"/>.</returns>
+    EventSource GetPartEventSource();
+
+  }
+
+}

--- a/Networking/SemanticData/Diagnostics/NetworkingEventSourceBase.cs
+++ b/Networking/SemanticData/Diagnostics/NetworkingEventSourceBase.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UAOOI.Networking.SemanticData.Diagnostics
+{
+  public abstract class NetworkingEventSourceBase : INetworkingEventSourceProvider
+  {
+
+    public const EventTask Consumer = (EventTask)1;
+    public const EventTask Producer = (EventTask)2;
+    public const EventTask ConsumerProducer = (EventTask)3;
+
+    public abstract EventSource GetPartEventSource();
+
+  }
+}

--- a/Networking/SemanticData/Networking.SemanticData.csproj
+++ b/Networking/SemanticData/Networking.SemanticData.csproj
@@ -63,6 +63,8 @@
     <Compile Include="DataRepository\ConsumerBinding.cs" />
     <Compile Include="DataManagementSetup.cs" />
     <Compile Include="DataRepository\ConsumerBindingMonitoredValue.cs" />
+    <Compile Include="Diagnostics\INetworkingEventSourceProvider.cs" />
+    <Compile Include="Diagnostics\NetworkingEventSourceBase.cs" />
     <Compile Include="Diagnostics\SemanticEventSource.cs" />
     <Compile Include="Encoding\CommonDefinitions.cs" />
     <Compile Include="Encoding\IBinaryEncoder.cs" />

--- a/Networking/Tests/ReferenceApplicationUnitTest/MEF/DefaultServiceRegistrarUnitTest.cs
+++ b/Networking/Tests/ReferenceApplicationUnitTest/MEF/DefaultServiceRegistrarUnitTest.cs
@@ -8,8 +8,8 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using UAOOI.Common.Infrastructure.Diagnostic;
 using UAOOI.Networking.ReferenceApplication.MEF;
+using UAOOI.Networking.SemanticData.Diagnostics;
 using UAOOI.Networking.SemanticData.MessageHandling;
-using UAOOI.Networking.UDPMessageHandler;
 
 namespace UAOOI.Networking.ReferenceApplication.UnitTest.MEF
 {
@@ -75,6 +75,8 @@ namespace UAOOI.Networking.ReferenceApplication.UnitTest.MEF
         Assert.IsNotNull(_interface);
         IMessageHandlerFactory _messageHandlerFactory = _container.GetExportedValue<IMessageHandlerFactory>();
         Assert.IsNotNull(_messageHandlerFactory);
+        NetworkingEventSourceBase _baseEventSource = _messageHandlerFactory as NetworkingEventSourceBase;
+        Assert.IsNotNull(_baseEventSource);
       }
     }
     [Export(typeof(IInterface))]

--- a/Networking/Tests/UDPMessageHandler.UnitTest/BinaryUDPPackageReaderTestClass.cs
+++ b/Networking/Tests/UDPMessageHandler.UnitTest/BinaryUDPPackageReaderTestClass.cs
@@ -1,32 +1,28 @@
 ﻿
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using UAOOI.Networking.SemanticData.Encoding;
 using System.Net;
 using System.Threading;
 using System.Xml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UAOOI.Networking.SemanticData.Encoding;
 
 namespace UAOOI.Networking.UDPMessageHandler.UnitTest
 {
   [TestClass]
   public class BinaryUDPPackageReaderTestClass
   {
-
     #region TestMethod
     [TestMethod]
     [TestCategory("ReferenceApplication_BinaryUDPPackageReaderTestClass")]
     public void CreatorTestMethod()
     {
-      bool _ExclusiveAddressUse = true;
-      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
       {
         Assert.IsNotNull(_reader1);
-        _reader1.ReuseAddress = _ExclusiveAddressUse;
-        _reader1.MulticastGroup = IPAddress.Parse("239.0.0.1");
         _reader1.State.Enable();
         Assert.IsNotNull(_reader1.MulticastGroup);
       }
-      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
       {
         Assert.IsNotNull(_reader1);
         _reader1.State.Enable();
@@ -37,12 +33,12 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest
     public void ExclusiveAddressUseTrueTestMethod()
     {
       bool _ExclusiveAddressUse = true;
-      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
       {
         Assert.IsNotNull(_reader1);
         _reader1.ReuseAddress = _ExclusiveAddressUse;
         _reader1.State.Enable();
-        using (BinaryUDPPackageReader _reader2 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+        using (BinaryUDPPackageReader _reader2 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
         {
           Assert.IsNotNull(_reader2);
           _reader2.ReuseAddress = _ExclusiveAddressUse;
@@ -56,14 +52,12 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest
     public void ExclusiveAddressUseFalseTestMethod()
     {
       bool _ExclusiveAddressUse = false;
-      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
       {
-        Assert.IsNotNull(_reader1);
         _reader1.ReuseAddress = _ExclusiveAddressUse;
         _reader1.State.Enable();
-        using (BinaryUDPPackageReader _reader2 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+        using (BinaryUDPPackageReader _reader2 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
         {
-          Assert.IsNotNull(_reader2);
           _reader2.ReuseAddress = _ExclusiveAddressUse;
           _reader2.State.Enable();
         }
@@ -75,9 +69,8 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest
     public void ExclusiveAddressOperationalTestMethod()
     {
       bool _ExclusiveAddressUse = true;
-      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
       {
-        Assert.IsNotNull(_reader1);
         _reader1.ReuseAddress = _ExclusiveAddressUse;
         _reader1.State.Enable();
         _reader1.ReuseAddress = _ExclusiveAddressUse;
@@ -88,14 +81,10 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest
     [ExpectedException(typeof(InvalidOperationException))]
     public void ExclusiveMulticastGroupTestMethod()
     {
-      bool _ExclusiveAddressUse = true;
-      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), 4840))
+      using (BinaryUDPPackageReader _reader1 = new BinaryUDPPackageReader(new UADecoder(), LocalUDPConfiguration.GetReaderConfiguration()))
       {
         try
         {
-          Assert.IsNotNull(_reader1);
-          _reader1.ReuseAddress = _ExclusiveAddressUse;
-          _reader1.MulticastGroup = IPAddress.Parse("239.0.0.1");
           _reader1.State.Enable();
           Thread.Sleep(200);
         }
@@ -181,6 +170,17 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest
       public XmlElement ReadXmlElement(IBinaryDecoder decoder)
       {
         throw new NotImplementedException();
+      }
+    }
+    private static class LocalUDPConfiguration
+    {
+      internal static MessageHandlerFactory.UDPReaderConfiguration GetReaderConfiguration()
+      {
+        bool _ExclusiveAddressUse = true;
+        int UDPPortNumber = 4840;
+        bool JoinMulticastGroup = true;
+        string DefaultMulticastGroup = "239.255.255.1";
+        return MessageHandlerFactory.UDPReaderConfiguration.Parse($"{UDPPortNumber},{JoinMulticastGroup},{DefaultMulticastGroup},{_ExclusiveAddressUse}");
       }
     }
     #endregion

--- a/Networking/Tests/UDPMessageHandler.UnitTest/Diagnostic/UDPMessageHandlerSemanticEventSourceUnitTest.cs
+++ b/Networking/Tests/UDPMessageHandler.UnitTest/Diagnostic/UDPMessageHandlerSemanticEventSourceUnitTest.cs
@@ -3,6 +3,7 @@ using System;
 using System.Diagnostics.Tracing;
 using System.IO;
 using System.Net;
+using System.Net.NetworkInformation;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging;
 using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -37,19 +38,19 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest.Diagnostic
         _sinkSubscription.Sink.EnableEvents(_log, EventLevel.LogAlways, Keywords.All);
 
         Assert.IsNull(_lastEvent);
-        _log.MessageContent(new IPEndPoint(new IPAddress(new byte[] { 192, 168, 0, 0 }), 25), 100, new byte[] { 1, 2, 3, 4 });
+        _log.ReceivedMessageContent(new IPEndPoint(new IPAddress(new byte[] { 192, 168, 0, 0 }), 25), 100, new byte[] { 1, 2, 3, 4 });
         Assert.AreEqual<int>(1, _calls);
         Assert.IsNotNull(_lastEvent);
 
         //_lastEvent content
         Assert.AreEqual<int>(5, _lastEvent.EventId);
         Assert.AreEqual<Guid>(Guid.Empty, _lastEvent.ActivityId);
-        string _message  = "Message: 192.168.0.0:25 [100]: 1,2,3,4";
+        string _message  = "Received message: 192.168.0.0:25 [100]: 1,2,3,4";
         Assert.AreEqual<string>(_message, _lastEvent.FormattedMessage, _lastEvent.FormattedMessage);
 
         Assert.AreEqual<string>("System.Collections.ObjectModel.ReadOnlyCollection`1[System.Object]", _lastEvent.Payload.ToString(), _lastEvent.Payload.ToString());
         Assert.AreEqual<int>(1, _lastEvent.Payload.Count);
-        Assert.IsInstanceOfType(_lastEvent.Payload[0].ToString(), typeof(String));
+        Assert.IsInstanceOfType(_lastEvent.Payload[0], typeof(String));
         Assert.AreEqual<string>("192.168.0.0:25 [100]: 1,2,3,4", _lastEvent.Payload[0].ToString());
         Assert.AreEqual<string>("payload0", _lastEvent.Schema.Payload[0]);
 
@@ -58,7 +59,6 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest.Diagnostic
         Assert.AreEqual<string>("Consumer", _lastEvent.Schema.TaskName);
         Assert.AreEqual<EventTask>(UDPMessageHandlerSemanticEventSource.Tasks.Consumer, _lastEvent.Schema.Task);
       }
-
     }
     [TestMethod]
     public void JoiningMulticastGroupTest()
@@ -80,14 +80,14 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest.Diagnostic
         Assert.IsNotNull(_lastEvent);
 
         //_lastEvent content
-        Assert.AreEqual<int>(6, _lastEvent.EventId);
+        Assert.AreEqual<int>(7, _lastEvent.EventId);
         Assert.AreEqual<Guid>(Guid.Empty, _lastEvent.ActivityId);
         string _message = "Joining the multicast group: 192.168.0.0";
         Assert.AreEqual<string>(_message, _lastEvent.FormattedMessage, _lastEvent.FormattedMessage);
 
         Assert.AreEqual<string>("System.Collections.ObjectModel.ReadOnlyCollection`1[System.Object]", _lastEvent.Payload.ToString(), _lastEvent.Payload.ToString());
         Assert.AreEqual<int>(1, _lastEvent.Payload.Count);
-        Assert.IsInstanceOfType(_lastEvent.Payload[0].ToString(), typeof(String));
+        Assert.IsInstanceOfType(_lastEvent.Payload[0], typeof(String));
         Assert.AreEqual<string>("192.168.0.0", _lastEvent.Payload[0].ToString());
         Assert.AreEqual<string>("payload0", _lastEvent.Schema.Payload[0]);
 
@@ -95,6 +95,46 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest.Diagnostic
         Assert.AreEqual<EventOpcode>(EventOpcode.Receive, _lastEvent.Schema.Opcode);
         Assert.AreEqual<string>("Consumer", _lastEvent.Schema.TaskName);
         Assert.AreEqual<EventTask>(UDPMessageHandlerSemanticEventSource.Tasks.Consumer, _lastEvent.Schema.Task);
+      }
+    }
+    [TestMethod]
+    public void ReaderUdpStatisticsTest()
+    {
+      EventEntry _lastEvent = null;
+      int _calls = 0;
+      ObservableEventListener _listener = new ObservableEventListener();
+      IDisposable subscription = _listener.Subscribe(x => { _calls++; _lastEvent = x; });
+      using (SinkSubscription<ObservableEventListener> _sinkSubscription = new SinkSubscription<ObservableEventListener>(subscription, _listener))
+      {
+        Assert.IsNotNull(_sinkSubscription.Sink);
+
+        UDPMessageHandlerSemanticEventSource _log = UDPMessageHandlerSemanticEventSource.Log;
+        _sinkSubscription.Sink.EnableEvents(_log, EventLevel.LogAlways, Keywords.All);
+
+        Assert.IsNull(_lastEvent);
+        _log.ReaderUdpStatistics(new UdpStatisticsTest());
+        Assert.AreEqual<int>(1, _calls);
+        Assert.IsNotNull(_lastEvent);
+
+        //_lastEvent content
+        Assert.AreEqual<int>(8, _lastEvent.EventId);
+        Assert.AreEqual<Guid>(Guid.Empty, _lastEvent.ActivityId);
+        string _message = "Udp statistics: datagrams received = 100 sent = 100";
+        Assert.AreEqual<string>(_message, _lastEvent.FormattedMessage, _lastEvent.FormattedMessage);
+
+        Assert.AreEqual<string>("System.Collections.ObjectModel.ReadOnlyCollection`1[System.Object]", _lastEvent.Payload.ToString(), _lastEvent.Payload.ToString());
+        Assert.AreEqual<int>(2, _lastEvent.Payload.Count);
+        Assert.IsInstanceOfType(_lastEvent.Payload[0], typeof(long));
+        Assert.AreEqual<string>("100", _lastEvent.Payload[0].ToString());
+        Assert.AreEqual<string>("datagramsReceived", _lastEvent.Schema.Payload[0]);
+        Assert.IsInstanceOfType(_lastEvent.Payload[1], typeof(long));
+        Assert.AreEqual<string>("100", _lastEvent.Payload[1].ToString());
+        Assert.AreEqual<string>("datagramsSent", _lastEvent.Schema.Payload[1]);
+
+        Assert.AreEqual<string>("Info", _lastEvent.Schema.OpcodeName);
+        Assert.AreEqual<EventOpcode>(EventOpcode.Info, _lastEvent.Schema.Opcode);
+        Assert.AreEqual<string>("Stack", _lastEvent.Schema.TaskName);
+        Assert.AreEqual<EventTask>(UDPMessageHandlerSemanticEventSource.Tasks.Stack, _lastEvent.Schema.Task);
       }
 
     }
@@ -120,7 +160,22 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest.Diagnostic
       _logFile.Refresh();
       Assert.IsTrue(_logFile.Length > 100);
       _FlatFileSink.Dispose();
-
     }
+
+    #region Instrumentation
+    private class UdpStatisticsTest : UdpStatistics
+    {
+      public override long DatagramsReceived => 100;
+
+      public override long DatagramsSent => 100;
+
+      public override long IncomingDatagramsDiscarded => 0;
+
+      public override long IncomingDatagramsWithErrors => 0;
+
+      public override int UdpListeners => 1;
+    }
+    #endregion
+
   }
 }

--- a/Networking/Tests/UDPMessageHandler.UnitTest/Diagnostic/UDPMessageHandlerSemanticEventSourceUnitTest.cs
+++ b/Networking/Tests/UDPMessageHandler.UnitTest/Diagnostic/UDPMessageHandlerSemanticEventSourceUnitTest.cs
@@ -1,0 +1,126 @@
+﻿
+using System;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Net;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging;
+using Microsoft.Practices.EnterpriseLibrary.SemanticLogging.Sinks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UAOOI.Networking.UDPMessageHandler.Diagnostic;
+
+namespace UAOOI.Networking.UDPMessageHandler.UnitTest.Diagnostic
+{
+  [TestClass]
+  public class UDPMessageHandlerSemanticEventSourceUnitTest
+  {
+
+    [TestMethod]
+    public void UDPMessageHandlerSemanticEventSourceTest()
+    {
+      UDPMessageHandlerSemanticEventSource _instance = UDPMessageHandlerSemanticEventSource.Log;
+      Assert.IsNull(_instance.ConstructionException);
+      Assert.AreEqual<string>("UAOOI-Networking-UDPMessageHandler-Diagnostic", _instance.Name);
+      Assert.AreEqual<EventSourceSettings>(EventSourceSettings.EtwManifestEventFormat, _instance.Settings);
+    }
+    [TestMethod]
+    public void ReactiveSubscribeTest()
+    {
+      EventEntry _lastEvent = null;
+      int _calls = 0;
+      ObservableEventListener _listener = new ObservableEventListener();
+      IDisposable subscription = _listener.Subscribe(x => { _calls++; _lastEvent = x; });
+      using (SinkSubscription<ObservableEventListener> _sinkSubscription = new SinkSubscription<ObservableEventListener>(subscription, _listener))
+      {
+        Assert.IsNotNull(_sinkSubscription.Sink);
+
+        UDPMessageHandlerSemanticEventSource _log = UDPMessageHandlerSemanticEventSource.Log;
+        _sinkSubscription.Sink.EnableEvents(_log, EventLevel.LogAlways, Keywords.All);
+
+        Assert.IsNull(_lastEvent);
+        _log.MessageContent(new IPEndPoint(new IPAddress(new byte[] { 192, 168, 0, 0 }), 25), 100, new byte[] { 1, 2, 3, 4 });
+        Assert.AreEqual<int>(1, _calls);
+        Assert.IsNotNull(_lastEvent);
+
+        //_lastEvent content
+        Assert.AreEqual<int>(5, _lastEvent.EventId);
+        Assert.AreEqual<Guid>(Guid.Empty, _lastEvent.ActivityId);
+        string _message  = "Message: 192.168.0.0:25 [100]: 1,2,3,4";
+        Assert.AreEqual<string>(_message, _lastEvent.FormattedMessage, _lastEvent.FormattedMessage);
+
+        Assert.AreEqual<string>("System.Collections.ObjectModel.ReadOnlyCollection`1[System.Object]", _lastEvent.Payload.ToString(), _lastEvent.Payload.ToString());
+        Assert.AreEqual<int>(1, _lastEvent.Payload.Count);
+        Assert.IsInstanceOfType(_lastEvent.Payload[0].ToString(), typeof(String));
+        Assert.AreEqual<string>("192.168.0.0:25 [100]: 1,2,3,4", _lastEvent.Payload[0].ToString());
+        Assert.AreEqual<string>("payload0", _lastEvent.Schema.Payload[0]);
+
+        Assert.AreEqual<string>("Start", _lastEvent.Schema.OpcodeName);
+        Assert.AreEqual<EventOpcode>(EventOpcode.Start, _lastEvent.Schema.Opcode);
+        Assert.AreEqual<string>("Consumer", _lastEvent.Schema.TaskName);
+        Assert.AreEqual<EventTask>(UDPMessageHandlerSemanticEventSource.Tasks.Consumer, _lastEvent.Schema.Task);
+      }
+
+    }
+    [TestMethod]
+    public void JoiningMulticastGroupTest()
+    {
+      EventEntry _lastEvent = null;
+      int _calls = 0;
+      ObservableEventListener _listener = new ObservableEventListener();
+      IDisposable subscription = _listener.Subscribe(x => { _calls++; _lastEvent = x; });
+      using (SinkSubscription<ObservableEventListener> _sinkSubscription = new SinkSubscription<ObservableEventListener>(subscription, _listener))
+      {
+        Assert.IsNotNull(_sinkSubscription.Sink);
+
+        UDPMessageHandlerSemanticEventSource _log = UDPMessageHandlerSemanticEventSource.Log;
+        _sinkSubscription.Sink.EnableEvents(_log, EventLevel.LogAlways, Keywords.All);
+
+        Assert.IsNull(_lastEvent);
+        _log.JoiningMulticastGroup(new IPAddress(new byte[] { 192, 168, 0, 0 }));
+        Assert.AreEqual<int>(1, _calls);
+        Assert.IsNotNull(_lastEvent);
+
+        //_lastEvent content
+        Assert.AreEqual<int>(6, _lastEvent.EventId);
+        Assert.AreEqual<Guid>(Guid.Empty, _lastEvent.ActivityId);
+        string _message = "Joining the multicast group: 192.168.0.0";
+        Assert.AreEqual<string>(_message, _lastEvent.FormattedMessage, _lastEvent.FormattedMessage);
+
+        Assert.AreEqual<string>("System.Collections.ObjectModel.ReadOnlyCollection`1[System.Object]", _lastEvent.Payload.ToString(), _lastEvent.Payload.ToString());
+        Assert.AreEqual<int>(1, _lastEvent.Payload.Count);
+        Assert.IsInstanceOfType(_lastEvent.Payload[0].ToString(), typeof(String));
+        Assert.AreEqual<string>("192.168.0.0", _lastEvent.Payload[0].ToString());
+        Assert.AreEqual<string>("payload0", _lastEvent.Schema.Payload[0]);
+
+        Assert.AreEqual<string>("Receive", _lastEvent.Schema.OpcodeName);
+        Assert.AreEqual<EventOpcode>(EventOpcode.Receive, _lastEvent.Schema.Opcode);
+        Assert.AreEqual<string>("Consumer", _lastEvent.Schema.TaskName);
+        Assert.AreEqual<EventTask>(UDPMessageHandlerSemanticEventSource.Tasks.Consumer, _lastEvent.Schema.Task);
+      }
+
+    }
+    [TestMethod]
+    public void LogFailure2LogToFlatFileTest()
+    {
+      string _filePath = $"{nameof(LogFailure2LogToFlatFileTest)}.log";
+      FileInfo _logFile = new FileInfo(_filePath);
+      if (_logFile.Exists)
+        _logFile.Delete();
+      MessageHandlerFactory _factory = new MessageHandlerFactory();
+      ObservableEventListener _listener = new ObservableEventListener();
+      UDPMessageHandlerSemanticEventSource _log = UDPMessageHandlerSemanticEventSource.Log;
+      _listener.EnableEvents(_log, EventLevel.LogAlways, Keywords.All);
+      SinkSubscription<FlatFileSink> _FlatFileSink = _listener.LogToFlatFile(_filePath);
+      _logFile.Refresh();
+      Assert.IsTrue(_logFile.Exists);
+      Assert.AreEqual<long>(0, _logFile.Length);
+
+      _log.Failure("LogFailure");
+
+      _FlatFileSink.Sink.FlushAsync();
+      _logFile.Refresh();
+      Assert.IsTrue(_logFile.Length > 100);
+      _FlatFileSink.Dispose();
+
+    }
+  }
+}

--- a/Networking/Tests/UDPMessageHandler.UnitTest/MessageHandlerFactoryUnitTest.cs
+++ b/Networking/Tests/UDPMessageHandler.UnitTest/MessageHandlerFactoryUnitTest.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using UAOOI.Networking.SemanticData.Diagnostics;
 
 namespace UAOOI.Networking.UDPMessageHandler.UnitTest
 {
@@ -43,6 +44,11 @@ namespace UAOOI.Networking.UDPMessageHandler.UnitTest
       Assert.AreEqual<string>("4840,localhost", _configuration.ToString());
       Assert.AreEqual<int>(UDPPortNumber, _configuration.UDPPortNumber);
       Assert.AreEqual<string>(RemoteHostName, _configuration.RemoteHostName);
+    }
+    [TestMethod]
+    public void MessageHandlerFactoryBaseTest()
+    {
+      Assert.IsTrue(typeof(NetworkingEventSourceBase).IsAssignableFrom( typeof(MessageHandlerFactory)));
     }
   }
 }

--- a/Networking/Tests/UDPMessageHandler.UnitTest/Networking.UDPMessageHandler.UnitTest.csproj
+++ b/Networking/Tests/UDPMessageHandler.UnitTest/Networking.UDPMessageHandler.UnitTest.csproj
@@ -45,18 +45,34 @@
     <AssemblyOriginatorKeyFile>OPCUAOOIKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\EnterpriseLibrary.SemanticLogging.2.0.1406.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Practices.EnterpriseLibrary.SemanticLogging.TextFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\EnterpriseLibrary.SemanticLogging.TextFile.2.0.1406.1\lib\net45\Microsoft.Practices.EnterpriseLibrary.SemanticLogging.TextFile.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\..\packages\MSTest.TestFramework.1.2.0\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Reactive.Core, Version=3.0.3000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Reactive.Core.3.1.1\lib\net46\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces, Version=3.0.1000.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
+      <HintPath>..\..\..\packages\System.Reactive.Interfaces.3.1.1\lib\net45\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BinaryUDPPackageReaderTestClass.cs" />
+    <Compile Include="Diagnostic\UDPMessageHandlerSemanticEventSourceUnitTest.cs" />
     <Compile Include="IPAddressValidationRuleUnitTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <AutoGen>True</AutoGen>

--- a/Networking/Tests/UDPMessageHandler.UnitTest/packages.config
+++ b/Networking/Tests/UDPMessageHandler.UnitTest/packages.config
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EnterpriseLibrary.SemanticLogging" version="2.0.1406.1" targetFramework="net461" />
+  <package id="EnterpriseLibrary.SemanticLogging.TextFile" version="2.0.1406.1" targetFramework="net461" />
   <package id="Microsoft.DependencyValidation.Analyzers" version="0.9.0" targetFramework="net461" />
   <package id="MSTest.TestAdapter" version="1.2.0" targetFramework="net461" />
   <package id="MSTest.TestFramework" version="1.2.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net461" />
+  <package id="System.Reactive.Core" version="3.1.1" targetFramework="net461" />
+  <package id="System.Reactive.Interfaces" version="3.1.1" targetFramework="net461" />
 </packages>

--- a/Networking/UDPMessageHandler/BinaryUDPPackageReader.cs
+++ b/Networking/UDPMessageHandler/BinaryUDPPackageReader.cs
@@ -28,7 +28,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     /// <param name="trace">The trace.</param>
     public BinaryUDPPackageReader(IUADecoder uaDecoder, int port) : base(uaDecoder)
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(BinaryUDPPackageReader));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(BinaryUDPPackageReader));
       State = new MyState(this);
       m_UDPPort = port;
     }
@@ -53,7 +53,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     /// </summary>
     public override void AttachToNetwork()
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(AttachToNetwork));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(AttachToNetwork));
       Debug.Assert(HandlerState.Operational != State.State);
     }
     /// <summary>
@@ -62,7 +62,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
     protected override void Dispose(bool disposing)
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(Dispose));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(Dispose));
 
       base.Dispose(disposing);
       if (!disposing)
@@ -178,7 +178,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     /// <param name="asyncResult">The asynchronous result.</param>
     private void ReceiveAsyncCallback(IAsyncResult asyncResult)
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(ReceiveAsyncCallback));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(ReceiveAsyncCallback));
       //if (!asyncResult.IsCompleted)
       //  return;
       try
@@ -191,26 +191,26 @@ namespace UAOOI.Networking.UDPMessageHandler
         //m_ViewModel.ConsumerFramesReceived = m_NumberOfPackages;
         //m_ViewModel.ConsumerReceivedBytes = m_NumberOfBytes;
         int _length = _receiveBytes == null ? -1 : _receiveBytes.Length;
-        SemanticEventSource.Log.MessageContent(_UEndPoint, _length, _receiveBytes);
+        UDPMessageHandlerSemanticEventSource.Log.MessageContent(_UEndPoint, _length, _receiveBytes);
         MemoryStream _stream = new MemoryStream(_receiveBytes, 0, _receiveBytes.Length);
         OnNewFrameArrived(new BinaryReader(_stream, System.Text.Encoding.UTF8));
-        SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(UdpStatisticsEvent));
+        UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(UdpStatisticsEvent));
         UdpStatisticsEvent?.Invoke(this, new UdpStatisticsEventArgs(m_Properties.GetUdpIPv4Statistics()));
         m_UdpClient.BeginReceive(new AsyncCallback(ReceiveAsyncCallback), m_UdpClient);
       }
       catch (ObjectDisposedException _ex)
       {
-        SemanticEventSource.Log.Failure($"ObjectDisposedException = {_ex.Message}");
+        UDPMessageHandlerSemanticEventSource.Log.Failure($"ObjectDisposedException = {_ex.Message}");
       }
       catch (Exception _ex)
       {
-        SemanticEventSource.Log.Failure($"Exception {_ex.Message}, type = {_ex.GetType().Name}");
+        UDPMessageHandlerSemanticEventSource.Log.Failure($"Exception {_ex.Message}, type = {_ex.GetType().Name}");
       }
     }
     //Methods
     private void OnEnable()
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(OnEnable));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(OnEnable));
       m_UdpClient = new UdpClient();
       m_UdpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, ReuseAddress);
       m_UdpClient.ExclusiveAddressUse = !ReuseAddress;
@@ -218,10 +218,10 @@ namespace UAOOI.Networking.UDPMessageHandler
       m_UdpClient.Client.Bind(_ep);
       if (m_MulticastGroup != null)
       {
-        SemanticEventSource.Log.JoiningMulticastGroup(m_MulticastGroup);
+        UDPMessageHandlerSemanticEventSource.Log.JoiningMulticastGroup(m_MulticastGroup);
         m_UdpClient.JoinMulticastGroup(m_MulticastGroup);
       }
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(m_UdpClient.BeginReceive)); 
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(m_UdpClient.BeginReceive)); 
       m_UdpClient.BeginReceive(new AsyncCallback(ReceiveAsyncCallback), m_UdpClient);
     }
     private void OnDisable()

--- a/Networking/UDPMessageHandler/BinaryUDPPackageReader.cs
+++ b/Networking/UDPMessageHandler/BinaryUDPPackageReader.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
@@ -22,23 +21,21 @@ namespace UAOOI.Networking.UDPMessageHandler
 
     #region creator
     /// <summary>
-    /// Initializes a new instance of the <see cref="BinaryUDPPackageReader"/> class.
+    /// Initializes a new instance of the <see cref="BinaryUDPPackageReader" /> class.
     /// </summary>
-    /// <param name="port">The port.</param>
-    /// <param name="trace">The trace.</param>
-    public BinaryUDPPackageReader(IUADecoder uaDecoder, int port) : base(uaDecoder)
+    /// <param name="uaDecoder">The ua decoder.</param>
+    /// <param name="configuration">The configuration of the reader.</param>
+    public BinaryUDPPackageReader(IUADecoder uaDecoder, MessageHandlerFactory.UDPReaderConfiguration configuration) : base(uaDecoder)
     {
-      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(BinaryUDPPackageReader));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), $"{nameof(BinaryUDPPackageReader)}({configuration.ToString()})");
       State = new MyState(this);
-      m_UDPPort = port;
+      m_UDPPort = configuration.UDPPortNumber;
+      MulticastGroup = configuration.DefaultMulticastGroup;
+      ReuseAddress = configuration.ReuseAddress;
     }
     #endregion
 
     #region BinaryDecoder
-    /// <summary>
-    /// Occurs when new package is received and processed.
-    /// </summary>
-    public event EventHandler<UdpStatisticsEventArgs> UdpStatisticsEvent;
     /// <summary>
     /// Gets or sets the state.
     /// </summary>
@@ -63,14 +60,13 @@ namespace UAOOI.Networking.UDPMessageHandler
     protected override void Dispose(bool disposing)
     {
       UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(Dispose));
-
       base.Dispose(disposing);
       if (!disposing)
         return;
-      if (m_UdpClient == null)
+      if (Client == null)
         return;
-      m_UdpClient.Close();
-      m_UdpClient = null;
+      Client.Close();
+      Client = null;
       m_MulticastGroup = null;
     }
     #endregion
@@ -95,10 +91,6 @@ namespace UAOOI.Networking.UDPMessageHandler
           throw new InvalidOperationException($"{nameof(MulticastGroup)} cannot be set the object is in Operational state");
         m_MulticastGroup = value;
       }
-    }
-    public UdpClient Client
-    {
-      get { return m_UdpClient; }
     }
     #endregion
 
@@ -164,14 +156,12 @@ namespace UAOOI.Networking.UDPMessageHandler
 
     }
     //vars
-    //private IConsumerViewModel m_ViewModel = null;
-    private int m_NumberOfBytes = 0;
-    private int m_NumberOfPackages = 0;
-    private UdpClient m_UdpClient;
+    private UdpClient Client { get; set; }
     private int m_UDPPort;
     private bool m_ReuseAddress = true;
     private IPAddress m_MulticastGroup = null;
     private IPGlobalProperties m_Properties = IPGlobalProperties.GetIPGlobalProperties();
+
     /// <summary>
     /// Implements <see cref="AsyncCallback"/> for UDP begin receive.
     /// </summary>
@@ -186,17 +176,11 @@ namespace UAOOI.Networking.UDPMessageHandler
         UdpClient _client = (UdpClient)asyncResult.AsyncState;
         IPEndPoint _UEndPoint = null;
         Byte[] _receiveBytes = _client.EndReceive(asyncResult, ref _UEndPoint);
-        m_NumberOfPackages++;
-        m_NumberOfBytes += _receiveBytes.Length;
-        //m_ViewModel.ConsumerFramesReceived = m_NumberOfPackages;
-        //m_ViewModel.ConsumerReceivedBytes = m_NumberOfBytes;
         int _length = _receiveBytes == null ? -1 : _receiveBytes.Length;
-        UDPMessageHandlerSemanticEventSource.Log.MessageContent(_UEndPoint, _length, _receiveBytes);
+        UDPMessageHandlerSemanticEventSource.Log.ReceivedMessageContent(_UEndPoint, _length, _receiveBytes);
         MemoryStream _stream = new MemoryStream(_receiveBytes, 0, _receiveBytes.Length);
         OnNewFrameArrived(new BinaryReader(_stream, System.Text.Encoding.UTF8));
-        UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(UdpStatisticsEvent));
-        UdpStatisticsEvent?.Invoke(this, new UdpStatisticsEventArgs(m_Properties.GetUdpIPv4Statistics()));
-        m_UdpClient.BeginReceive(new AsyncCallback(ReceiveAsyncCallback), m_UdpClient);
+        Client.BeginReceive(new AsyncCallback(ReceiveAsyncCallback), Client);
       }
       catch (ObjectDisposedException _ex)
       {
@@ -211,18 +195,18 @@ namespace UAOOI.Networking.UDPMessageHandler
     private void OnEnable()
     {
       UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(OnEnable));
-      m_UdpClient = new UdpClient();
-      m_UdpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, ReuseAddress);
-      m_UdpClient.ExclusiveAddressUse = !ReuseAddress;
+      Client = new UdpClient();
+      Client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, ReuseAddress);
+      Client.ExclusiveAddressUse = !ReuseAddress;
       IPEndPoint _ep = new IPEndPoint(IPAddress.Any, m_UDPPort);
-      m_UdpClient.Client.Bind(_ep);
+      Client.Client.Bind(_ep);
       if (m_MulticastGroup != null)
       {
         UDPMessageHandlerSemanticEventSource.Log.JoiningMulticastGroup(m_MulticastGroup);
-        m_UdpClient.JoinMulticastGroup(m_MulticastGroup);
+        Client.JoinMulticastGroup(m_MulticastGroup);
       }
-      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(m_UdpClient.BeginReceive)); 
-      m_UdpClient.BeginReceive(new AsyncCallback(ReceiveAsyncCallback), m_UdpClient);
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageReader), nameof(Client.BeginReceive));
+      Client.BeginReceive(new AsyncCallback(ReceiveAsyncCallback), Client);
     }
     private void OnDisable()
     {

--- a/Networking/UDPMessageHandler/BinaryUDPPackageWriter.cs
+++ b/Networking/UDPMessageHandler/BinaryUDPPackageWriter.cs
@@ -20,7 +20,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     public BinaryUDPPackageWriter(string remoteHostName, int remotePort, IUAEncoder uaEncoder) :
       base(uaEncoder, MessageLengthFieldTypeEnum.TwoBytes)
     {
-      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(BinaryUDPPackageWriter));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(BinaryUDPPackageWriter)}(RemoteHostName={remoteHostName},RemotePort={remotePort})");
       State = new MyState(this);
       m_RemoteHostName = remoteHostName;
       m_remotePort = remotePort;
@@ -35,8 +35,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     }
     public override void AttachToNetwork()
     {
-      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(BinaryUDPPackageWriter));
-      m_NumberOfAttachToNetwork++;
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(AttachToNetwork));
     }
     protected override void SendFrame(byte[] buffer)
     {
@@ -48,12 +47,8 @@ namespace UAOOI.Networking.UDPMessageHandler
           return;
         try
         {
-          m_NumberOfSentBytes += buffer.Length;
-          //m_ViewModel.BytesSent = m_NumberOfSentBytes;
-          m_NumberOfSentMessages++;
-          //m_ViewModel.PackagesSent = m_NumberOfSentMessages;
           IPEndPoint _IPEndPoint = new IPEndPoint(m_IPAddresses, m_remotePort);
-          UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(_UdpClient.Send)} m_NumberOfSentBytes = {m_NumberOfSentBytes}, m_NumberOfSentMessages = {m_NumberOfSentMessages}");
+          UDPMessageHandlerSemanticEventSource.Log.SentMessageContent(_IPEndPoint, buffer.Length, buffer);
           _UdpClient.Send(buffer, buffer.Length, _IPEndPoint);
         }
         catch (SocketException e)
@@ -80,8 +75,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
     protected override void Dispose(bool disposing)
     {
-      string _msg = String.Format("Entering Dispose disposing = {0}", disposing);
-      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(BinaryUDPPackageWriter)}({nameof(disposing)} = {disposing})");
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(Dispose)}({nameof(disposing)} = {disposing})");
       lock (this)
       {
         base.Dispose(disposing);
@@ -167,12 +161,6 @@ namespace UAOOI.Networking.UDPMessageHandler
       UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(UdpClient)} m_RemoteHostName: {m_RemoteHostName} Ip : {m_IPAddresses.ToString()}");
       m_UdpClient = new UdpClient();
     }
-    #endregion
-
-    #region diagnostic instrumentation
-    internal int m_NumberOfSentMessages = 0;
-    internal int m_NumberOfSentBytes = 0;
-    internal int m_NumberOfAttachToNetwork;
     #endregion
 
   }

--- a/Networking/UDPMessageHandler/BinaryUDPPackageWriter.cs
+++ b/Networking/UDPMessageHandler/BinaryUDPPackageWriter.cs
@@ -20,7 +20,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     public BinaryUDPPackageWriter(string remoteHostName, int remotePort, IUAEncoder uaEncoder) :
       base(uaEncoder, MessageLengthFieldTypeEnum.TwoBytes)
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(BinaryUDPPackageWriter));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(BinaryUDPPackageWriter));
       State = new MyState(this);
       m_RemoteHostName = remoteHostName;
       m_remotePort = remotePort;
@@ -35,12 +35,12 @@ namespace UAOOI.Networking.UDPMessageHandler
     }
     public override void AttachToNetwork()
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(BinaryUDPPackageWriter));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(BinaryUDPPackageWriter));
       m_NumberOfAttachToNetwork++;
     }
     protected override void SendFrame(byte[] buffer)
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(SendFrame)} buffer.Length = {buffer.Length}");
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(SendFrame)} buffer.Length = {buffer.Length}");
       lock (this)
       {
         UdpClient _UdpClient = m_UdpClient;
@@ -53,24 +53,24 @@ namespace UAOOI.Networking.UDPMessageHandler
           m_NumberOfSentMessages++;
           //m_ViewModel.PackagesSent = m_NumberOfSentMessages;
           IPEndPoint _IPEndPoint = new IPEndPoint(m_IPAddresses, m_remotePort);
-          SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(_UdpClient.Send)} m_NumberOfSentBytes = {m_NumberOfSentBytes}, m_NumberOfSentMessages = {m_NumberOfSentMessages}");
+          UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(_UdpClient.Send)} m_NumberOfSentBytes = {m_NumberOfSentBytes}, m_NumberOfSentMessages = {m_NumberOfSentMessages}");
           _UdpClient.Send(buffer, buffer.Length, _IPEndPoint);
         }
         catch (SocketException e)
         {
-          SemanticEventSource.Log.Failure($"SocketException caught!!! Source : { e.Source} Message : {e.Message}");
+          UDPMessageHandlerSemanticEventSource.Log.Failure($"SocketException caught!!! Source : { e.Source} Message : {e.Message}");
         }
         catch (ArgumentNullException e)
         {
-          SemanticEventSource.Log.Failure($"ArgumentNullException caught!!! Source : { e.Source} Message : {e.Message}");
+          UDPMessageHandlerSemanticEventSource.Log.Failure($"ArgumentNullException caught!!! Source : { e.Source} Message : {e.Message}");
         }
         catch (NullReferenceException e)
         {
-          SemanticEventSource.Log.Failure($"NullReferenceException caught!!! Source : { e.Source} Message : {e.Message}");
+          UDPMessageHandlerSemanticEventSource.Log.Failure($"NullReferenceException caught!!! Source : { e.Source} Message : {e.Message}");
         }
         catch (Exception e)
         {
-          SemanticEventSource.Log.Failure($"Exception caught!!! Source : { e.Source} Message : {e.Message}");
+          UDPMessageHandlerSemanticEventSource.Log.Failure($"Exception caught!!! Source : { e.Source} Message : {e.Message}");
         }
       }
     }
@@ -81,7 +81,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     protected override void Dispose(bool disposing)
     {
       string _msg = String.Format("Entering Dispose disposing = {0}", disposing);
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(BinaryUDPPackageWriter)}({nameof(disposing)} = {disposing})");
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(BinaryUDPPackageWriter)}({nameof(disposing)} = {disposing})");
       lock (this)
       {
         base.Dispose(disposing);
@@ -89,7 +89,7 @@ namespace UAOOI.Networking.UDPMessageHandler
           return;
         if (m_UdpClient == null)
           return;
-        SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(m_UdpClient.Close));
+        UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(m_UdpClient.Close));
         m_UdpClient.Close();
         m_UdpClient = null;
       }
@@ -156,7 +156,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     //Methods
     private void OnEnable()
     {
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(OnEnable));
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), nameof(OnEnable));
       Debug.Assert(m_UdpClient == null);
       // Get DNS host information.
       IPAddress[] _remoteHostAddresses = Dns.GetHostAddresses(m_RemoteHostName);
@@ -164,7 +164,7 @@ namespace UAOOI.Networking.UDPMessageHandler
       // Get first IPAddress in list return by DNS.
       m_IPAddresses = _remoteHostAddresses.Where<IPAddress>(x => x.AddressFamily == AddressFamily.InterNetwork).First<IPAddress>();
       Debug.Assert(m_IPAddresses != null);
-      SemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(UdpClient)} m_RemoteHostName: {m_RemoteHostName} Ip : {m_IPAddresses.ToString()}");
+      UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(BinaryUDPPackageWriter), $"{nameof(UdpClient)} m_RemoteHostName: {m_RemoteHostName} Ip : {m_IPAddresses.ToString()}");
       m_UdpClient = new UdpClient();
     }
     #endregion

--- a/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerDiagnosticExtension.cs
+++ b/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerDiagnosticExtension.cs
@@ -1,0 +1,22 @@
+﻿
+using System;
+using System.Linq;
+using System.Net;
+
+namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
+{
+  internal static class UDPMessageHandlerDiagnosticExtension
+  {
+    internal static void MessageContent(this UDPMessageHandlerSemanticEventSource eventSource, IPEndPoint endPoint, int length, byte[] message)
+    {
+      string _content =
+        ($"{endPoint.Address.ToString()}:{endPoint.Port} [{length}]: {String.Join(",", new ArraySegment<byte>(message, 0, Math.Min(message.Length, 80)).Select<byte, string>(x => x.ToString("X")).ToArray<string>())}");
+      eventSource.MessageContent(_content);
+    }
+    internal static void JoiningMulticastGroup(this UDPMessageHandlerSemanticEventSource eventSource, IPAddress multicastGroup)
+    {
+      eventSource.JoiningMulticastGroup(multicastGroup.ToString());
+    }
+
+  }
+}

--- a/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerDiagnosticExtension.cs
+++ b/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerDiagnosticExtension.cs
@@ -2,20 +2,32 @@
 using System;
 using System.Linq;
 using System.Net;
+using System.Net.NetworkInformation;
 
 namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
 {
   internal static class UDPMessageHandlerDiagnosticExtension
   {
-    internal static void MessageContent(this UDPMessageHandlerSemanticEventSource eventSource, IPEndPoint endPoint, int length, byte[] message)
+    internal static void ReceivedMessageContent(this UDPMessageHandlerSemanticEventSource eventSource, IPEndPoint endPoint, int length, byte[] message)
     {
-      string _content =
-        ($"{endPoint.Address.ToString()}:{endPoint.Port} [{length}]: {String.Join(",", new ArraySegment<byte>(message, 0, Math.Min(message.Length, 80)).Select<byte, string>(x => x.ToString("X")).ToArray<string>())}");
-      eventSource.MessageContent(_content);
+      eventSource.ReceivedMessageContent(MessageContentFormat(endPoint, length, message));
     }
+    internal static void SentMessageContent(this UDPMessageHandlerSemanticEventSource eventSource, IPEndPoint endPoint, int length, byte[] message)
+    {
+      eventSource.SentMessageContent(MessageContentFormat(endPoint, length, message));
+    }
+    private static string MessageContentFormat(IPEndPoint endPoint, int length, byte[] message)
+    {
+      return ($"{endPoint.Address.ToString()}:{endPoint.Port} [{length}]: {String.Join(",", new ArraySegment<byte>(message, 0, Math.Min(message.Length, 80)).Select<byte, string>(x => x.ToString("X")).ToArray<string>())}");
+    }
+
     internal static void JoiningMulticastGroup(this UDPMessageHandlerSemanticEventSource eventSource, IPAddress multicastGroup)
     {
       eventSource.JoiningMulticastGroup(multicastGroup.ToString());
+    }
+    internal static void ReaderUdpStatistics(this UDPMessageHandlerSemanticEventSource eventSource, UdpStatistics payload0)
+    {
+      eventSource.ReaderUdpStatistics(payload0.DatagramsReceived, payload0.DatagramsSent);
     }
 
   }

--- a/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerSemanticEventSource.cs
+++ b/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerSemanticEventSource.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
 {
   [EventSource(Name = "UAOOI-Networking-UDPMessageHandler-Diagnostic")]
-  public class SemanticEventSource : EventSource
+  public class UDPMessageHandlerSemanticEventSource : EventSource
   {
     /// <summary>
     /// Class Keywords - defines the local keywords (flags) that apply to events.
@@ -19,6 +19,9 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
       public const EventKeywords Performance = (EventKeywords)4;
     }
 
+    /// <summary>
+    /// Class Tasks.
+    /// </summary>
     internal class Tasks
     {
       public const EventTask Consumer = (EventTask)1;
@@ -26,10 +29,10 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     }
 
     /// <summary>
-    /// Gets the log - implements singleton of the <see cref="SemanticEventSource"/>.
+    /// Gets the log - implements singleton of the <see cref="UDPMessageHandlerSemanticEventSource"/>.
     /// </summary>
     /// <value>The log.</value>
-    internal static SemanticEventSource Log { get; } = new SemanticEventSource();
+    internal static UDPMessageHandlerSemanticEventSource Log { get; } = new UDPMessageHandlerSemanticEventSource();
 
     [Event(1, Message = "Application Failure: {0}", Opcode = EventOpcode.Info, Task = EventTask.None, Level = EventLevel.Critical, Keywords = Keywords.Diagnostic)]
     internal void Failure(string message)
@@ -46,7 +49,7 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     {
       if (this.IsEnabled()) this.WriteEvent(3, className, methodName);
     }
-    private SemanticEventSource() { }
+    private UDPMessageHandlerSemanticEventSource() { }
 
     [Event(4, Message = "Unexpected end of message while reading #{0} element.", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Warning)]
 

--- a/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerSemanticEventSource.cs
+++ b/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerSemanticEventSource.cs
@@ -23,7 +23,10 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     {
       public const EventTask Consumer = (EventTask)1;
       public const EventTask Producer = (EventTask)2;
+      public const EventTask Stack = (EventTask)3;
+      public const EventTask Infrastructure = (EventTask)4;
     }
+
 
     /// <summary>
     /// Gets the log - implements singleton of the <see cref="UDPMessageHandlerSemanticEventSource"/>.
@@ -34,34 +37,47 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     [Event(1, Message = "Application Failure: {0}", Opcode = EventOpcode.Start, Task = Tasks.Consumer, Level = EventLevel.Critical, Keywords = Keywords.Diagnostic)]
     public void Failure(string message)
     {
-      this.WriteEvent(1, message);
+      WriteEvent(1, message);
     }
-    [Event(2, Message = "Starting up.", Keywords = Keywords.Performance, Level = EventLevel.Informational)]
-    public void Startup()
+    [Event(2, Message = "Starting up {0}.", Task = Tasks.Infrastructure, Keywords = Keywords.Performance, Level = EventLevel.Informational)]
+    internal void Startup(string stackName)
     {
-      this.WriteEvent(2);
+      WriteEvent(2, stackName);
     }
-    [Event(3, Message = "Entering method {0}.{1}", Opcode = EventOpcode.Start, Task = EventTask.None, Keywords = Keywords.Performance, Level = EventLevel.Informational)]
+    [Event(3, Message = "Entering method {0}.{1}", Opcode = EventOpcode.Start, Task = EventTask.None, Keywords = Keywords.Performance, Level = EventLevel.Verbose)]
     internal void EnteringMethod(string className, string methodName)
     {
-      if (this.IsEnabled()) this.WriteEvent(3, className, methodName);
+      if (IsEnabled())
+        WriteEvent(3, className, methodName);
     }
     [Event(4, Message = "Unexpected end of message while reading #{0} element.", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Warning)]
     internal void MessageInconsistency(int i)
     {
-      this.WriteEvent(4, i);
+      WriteEvent(4, i);
     }
-    [Event(5, Message = "Message: {0}", Opcode = EventOpcode.Start, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Warning)]
-    internal void MessageContent(string payload0)
+    [Event(5, Message = "Received message: {0}", Opcode = EventOpcode.Start, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Verbose)]
+    internal void ReceivedMessageContent(string payload0)
     {
       WriteEvent(5, payload0);
     }
-    [Event(6, Message = "Joining the multicast group: {0}", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Informational)]
-    internal void JoiningMulticastGroup(string payload0)
+    [Event(6, Message = "Sent message: {0}", Opcode = EventOpcode.Start, Task = Tasks.Producer, Keywords = Keywords.PackageContent, Level = EventLevel.Verbose)]
+    internal void SentMessageContent(string payload0)
     {
       WriteEvent(6, payload0);
     }
+    [Event(7, Message = "Joining the multicast group: {0}", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Informational)]
+    internal void JoiningMulticastGroup(string payload0)
+    {
+      WriteEvent(7, payload0);
+    }
+    [Event(8, Message = "Udp statistics: datagrams received = {0} sent = {1}", Opcode = EventOpcode.Info, Task = Tasks.Stack, Keywords = Keywords.Performance, Level = EventLevel.Informational)]
+
+    internal void ReaderUdpStatistics(long datagramsReceived, long datagramsSent)
+    {
+      WriteEvent(8, datagramsReceived, datagramsSent);
+    }
     private UDPMessageHandlerSemanticEventSource() { }
+
   }
 
 }

--- a/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerSemanticEventSource.cs
+++ b/Networking/UDPMessageHandler/Diagnostic/UDPMessageHandlerSemanticEventSource.cs
@@ -1,8 +1,5 @@
 ﻿
-using System;
 using System.Diagnostics.Tracing;
-using System.Net;
-using System.Linq;
 
 namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
 {
@@ -12,7 +9,7 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     /// <summary>
     /// Class Keywords - defines the local keywords (flags) that apply to events.
     /// </summary>
-    internal class Keywords
+    public class Keywords
     {
       public const EventKeywords PackageContent = (EventKeywords)1;
       public const EventKeywords Diagnostic = (EventKeywords)2;
@@ -22,7 +19,7 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     /// <summary>
     /// Class Tasks.
     /// </summary>
-    internal class Tasks
+    public class Tasks
     {
       public const EventTask Consumer = (EventTask)1;
       public const EventTask Producer = (EventTask)2;
@@ -34,13 +31,13 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     /// <value>The log.</value>
     internal static UDPMessageHandlerSemanticEventSource Log { get; } = new UDPMessageHandlerSemanticEventSource();
 
-    [Event(1, Message = "Application Failure: {0}", Opcode = EventOpcode.Info, Task = EventTask.None, Level = EventLevel.Critical, Keywords = Keywords.Diagnostic)]
-    internal void Failure(string message)
+    [Event(1, Message = "Application Failure: {0}", Opcode = EventOpcode.Start, Task = Tasks.Consumer, Level = EventLevel.Critical, Keywords = Keywords.Diagnostic)]
+    public void Failure(string message)
     {
       this.WriteEvent(1, message);
     }
     [Event(2, Message = "Starting up.", Keywords = Keywords.Performance, Level = EventLevel.Informational)]
-    internal void Startup()
+    public void Startup()
     {
       this.WriteEvent(2);
     }
@@ -49,26 +46,23 @@ namespace UAOOI.Networking.UDPMessageHandler.Diagnostic
     {
       if (this.IsEnabled()) this.WriteEvent(3, className, methodName);
     }
-    private UDPMessageHandlerSemanticEventSource() { }
-
     [Event(4, Message = "Unexpected end of message while reading #{0} element.", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Warning)]
-
     internal void MessageInconsistency(int i)
     {
       this.WriteEvent(4, i);
     }
-    [Event(5, Message = "Message: {0}", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Warning)]
-    internal void MessageContent(IPEndPoint endPoint, int length, byte[] message)
+    [Event(5, Message = "Message: {0}", Opcode = EventOpcode.Start, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Warning)]
+    internal void MessageContent(string payload0)
     {
-      string _content = 
-        ($"<{endPoint.Address.ToString()}:{endPoint.Port} [{length}]>: {String.Join(", ", new ArraySegment<byte>(message, 0, Math.Min(message.Length, 80)).Select<byte, string>(x => x.ToString("X")).ToArray<string>())}");
-      WriteEvent(5, _content);
+      WriteEvent(5, payload0);
     }
-    [Event(5, Message = "Joining the multicast group: {m_MulticastGroup} {0}", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Informational)]
-
-    internal void JoiningMulticastGroup(IPAddress multicastGroup)
+    [Event(6, Message = "Joining the multicast group: {0}", Opcode = EventOpcode.Receive, Task = Tasks.Consumer, Keywords = Keywords.PackageContent, Level = EventLevel.Informational)]
+    internal void JoiningMulticastGroup(string payload0)
     {
-      WriteEvent(5, multicastGroup);
+      WriteEvent(6, payload0);
     }
+    private UDPMessageHandlerSemanticEventSource() { }
   }
+
 }
+

--- a/Networking/UDPMessageHandler/MessageHandlerFactory.cs
+++ b/Networking/UDPMessageHandler/MessageHandlerFactory.cs
@@ -58,6 +58,7 @@ namespace UAOOI.Networking.UDPMessageHandler
     /// <returns>An object implementing <see cref="T:UAOOI.Networking.SemanticData.MessageHandling.IMessageReader" /> that provides functionality supporting reading the messages from the wire.</returns>
     IMessageReader IMessageHandlerFactory.GetIMessageReader(string name, string configuration, IUADecoder uaDecoder)
     {
+      Diagnostic.UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(MessageHandlerFactory), $"{nameof(IMessageHandlerFactory.GetIMessageReader)}{{ name = {name}, configuration= {configuration} }}");
       UDPReaderConfiguration _configuration = UDPReaderConfiguration.Parse(configuration);
       BinaryUDPPackageReader _ret = new BinaryUDPPackageReader(uaDecoder, _configuration.UDPPortNumber);
       _ret.MulticastGroup = _configuration.DefaultMulticastGroup;

--- a/Networking/UDPMessageHandler/MessageHandlerFactory.cs
+++ b/Networking/UDPMessageHandler/MessageHandlerFactory.cs
@@ -6,6 +6,7 @@ using System.Net;
 using UAOOI.Networking.SemanticData.Diagnostics;
 using UAOOI.Networking.SemanticData.Encoding;
 using UAOOI.Networking.SemanticData.MessageHandling;
+using UAOOI.Networking.UDPMessageHandler.Diagnostic;
 
 namespace UAOOI.Networking.UDPMessageHandler
 {
@@ -20,7 +21,38 @@ namespace UAOOI.Networking.UDPMessageHandler
 
     #region IMessageHandlerFactory
     /// <summary>
-    /// Class UDPReaderConfiguration encapsulating configuration for <see cref="IMessageHandlerFactory.GetIMessageReader"/>.
+    /// Gets the message reader.
+    /// </summary>
+    /// <param name="name">The name of the reader.</param>
+    /// <param name="configuration">The configuration of the object implementing the <see cref="T:UAOOI.Networking.SemanticData.MessageHandling.IMessageReader" />.</param>
+    /// <param name="uaDecoder">The decoder that provides methods to be used to decode OPC UA Built-in types.</param>
+    /// <returns>An object implementing <see cref="T:UAOOI.Networking.SemanticData.MessageHandling.IMessageReader" /> that provides functionality supporting reading the messages from the wire.</returns>
+    IMessageReader IMessageHandlerFactory.GetIMessageReader(string name, string configuration, IUADecoder uaDecoder)
+    {
+      UDPMessageHandlerSemanticEventSource.Log.Startup($"{nameof(IMessageHandlerFactory.GetIMessageReader)}{{ name = {name}, configuration= {configuration} }}");
+      UDPReaderConfiguration _configuration = UDPReaderConfiguration.Parse(configuration);
+      BinaryUDPPackageReader _ret = new BinaryUDPPackageReader(uaDecoder, _configuration);
+      return _ret;
+    }
+    /// <summary>
+    /// Gets the new instance of <see cref="IMessageWriter" />.
+    /// </summary>
+    /// <param name="name">The name of thw writer.</param>
+    /// <param name="configuration">The configuration of the object implementing the <see cref="T:UAOOI.Networking.SemanticData.MessageHandling.IMessageWriter" />.</param>
+    /// <param name="uaEncoder">The encoder that provides methods to be used to encode OPC UA Built-in types.</param>
+    /// <returns>An instance of <see cref="IMessageWriter" /> that provides functionality supporting writing the messages on the wire..</returns>
+    IMessageWriter IMessageHandlerFactory.GetIMessageWriter(string name, string configuration, IUAEncoder uaEncoder)
+    {
+      UDPMessageHandlerSemanticEventSource.Log.Startup($"{nameof(IMessageHandlerFactory.GetIMessageWriter)}{{ name = {name}, configuration= {configuration} }}");
+      UDPWriterConfiguration _configuration = UDPWriterConfiguration.Parse(configuration);
+      BinaryUDPPackageWriter _ret = new BinaryUDPPackageWriter(_configuration.RemoteHostName, _configuration.UDPPortNumber, uaEncoder);
+      return _ret;
+    }
+    #endregion
+
+    #region internal API
+    /// <summary>
+    /// Class UDPReaderConfiguration encapsulates configuration for <see cref="IMessageHandlerFactory.GetIMessageReader"/>.
     /// </summary>
     internal class UDPReaderConfiguration
     {
@@ -48,26 +80,9 @@ namespace UAOOI.Networking.UDPMessageHandler
       private UDPReaderConfiguration() { }
       private bool JoinMulticastGroup;
 
-    }
-    /// <summary>
-    /// Gets the message reader.
-    /// </summary>
-    /// <param name="name">The name of the reader.</param>
-    /// <param name="configuration">The configuration of the object implementing the <see cref="T:UAOOI.Networking.SemanticData.MessageHandling.IMessageReader" />.</param>
-    /// <param name="uaDecoder">The decoder that provides methods to be used to decode OPC UA Built-in types.</param>
-    /// <returns>An object implementing <see cref="T:UAOOI.Networking.SemanticData.MessageHandling.IMessageReader" /> that provides functionality supporting reading the messages from the wire.</returns>
-    IMessageReader IMessageHandlerFactory.GetIMessageReader(string name, string configuration, IUADecoder uaDecoder)
-    {
-      Diagnostic.UDPMessageHandlerSemanticEventSource.Log.EnteringMethod(nameof(MessageHandlerFactory), $"{nameof(IMessageHandlerFactory.GetIMessageReader)}{{ name = {name}, configuration= {configuration} }}");
-      UDPReaderConfiguration _configuration = UDPReaderConfiguration.Parse(configuration);
-      BinaryUDPPackageReader _ret = new BinaryUDPPackageReader(uaDecoder, _configuration.UDPPortNumber);
-      _ret.MulticastGroup = _configuration.DefaultMulticastGroup;
-      _ret.ReuseAddress = _configuration.ReuseAddress;
-      return _ret;
-    }
-    /// <summary>
-    /// Class UDPWriterConfiguration encapsulating configuration for <see cref="IMessageHandlerFactory.GetIMessageWriter"/>.
-    /// </summary>
+    }    /// <summary>
+         /// Class UDPWriterConfiguration encapsulates configuration for <see cref="IMessageHandlerFactory.GetIMessageWriter"/>.
+         /// </summary>
     internal class UDPWriterConfiguration
     {
       internal static UDPWriterConfiguration Parse(string configuration)
@@ -90,26 +105,12 @@ namespace UAOOI.Networking.UDPMessageHandler
       private UDPWriterConfiguration() { }
 
     }
-    /// <summary>
-    /// Gets the new instance of <see cref="IMessageWriter"/>.
-    /// </summary>
-    /// <param name="name">The name.</param>
-    /// <param name="configuration">The configuration.</param>
-    /// <remarks>It is intentionally not implemented</remarks>
-    /// <returns>An instance of <see cref="IMessageWriter"/>.</returns>
-    /// <exception cref="System.NotImplementedException"></exception>
-    IMessageWriter IMessageHandlerFactory.GetIMessageWriter(string name, string configuration, IUAEncoder uaEncoder)
-    {
-      UDPWriterConfiguration _configuration = UDPWriterConfiguration.Parse(configuration);
-      BinaryUDPPackageWriter _ret = new BinaryUDPPackageWriter(_configuration.RemoteHostName, _configuration.UDPPortNumber, uaEncoder);
-      return _ret;
-    }
     #endregion
 
     #region NetworkingEventSourceBase
     public override EventSource GetPartEventSource()
     {
-      return Diagnostic.UDPMessageHandlerSemanticEventSource.Log;
+      return UDPMessageHandlerSemanticEventSource.Log;
     }
     #endregion
 

--- a/Networking/UDPMessageHandler/MessageHandlerFactory.cs
+++ b/Networking/UDPMessageHandler/MessageHandlerFactory.cs
@@ -1,7 +1,9 @@
 ﻿
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics.Tracing;
 using System.Net;
+using UAOOI.Networking.SemanticData.Diagnostics;
 using UAOOI.Networking.SemanticData.Encoding;
 using UAOOI.Networking.SemanticData.MessageHandling;
 
@@ -13,7 +15,7 @@ namespace UAOOI.Networking.UDPMessageHandler
   /// </summary>
   [Export(typeof(IMessageHandlerFactory))]
   [PartCreationPolicy(CreationPolicy.Shared)]
-  public class MessageHandlerFactory : IMessageHandlerFactory
+  public class MessageHandlerFactory : NetworkingEventSourceBase, IMessageHandlerFactory
   {
 
     #region IMessageHandlerFactory
@@ -100,6 +102,13 @@ namespace UAOOI.Networking.UDPMessageHandler
       UDPWriterConfiguration _configuration = UDPWriterConfiguration.Parse(configuration);
       BinaryUDPPackageWriter _ret = new BinaryUDPPackageWriter(_configuration.RemoteHostName, _configuration.UDPPortNumber, uaEncoder);
       return _ret;
+    }
+    #endregion
+
+    #region NetworkingEventSourceBase
+    public override EventSource GetPartEventSource()
+    {
+      return Diagnostic.UDPMessageHandlerSemanticEventSource.Log;
     }
     #endregion
 

--- a/Networking/UDPMessageHandler/Networking.UDPMessageHandler.csproj
+++ b/Networking/UDPMessageHandler/Networking.UDPMessageHandler.csproj
@@ -49,7 +49,7 @@
   <ItemGroup>
     <Compile Include="BinaryUDPPackageReader.cs" />
     <Compile Include="BinaryUDPPackageWriter.cs" />
-    <Compile Include="Diagnostic\SemanticEventSource.cs" />
+    <Compile Include="Diagnostic\UDPMessageHandlerSemanticEventSource.cs" />
     <Compile Include="IPAddressValidationRule.cs" />
     <Compile Include="MessageHandlerFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/Networking/UDPMessageHandler/Networking.UDPMessageHandler.csproj
+++ b/Networking/UDPMessageHandler/Networking.UDPMessageHandler.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>IDE0001,IDE0002,IDE0003</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Networking/UDPMessageHandler/Networking.UDPMessageHandler.csproj
+++ b/Networking/UDPMessageHandler/Networking.UDPMessageHandler.csproj
@@ -49,6 +49,7 @@
   <ItemGroup>
     <Compile Include="BinaryUDPPackageReader.cs" />
     <Compile Include="BinaryUDPPackageWriter.cs" />
+    <Compile Include="Diagnostic\UDPMessageHandlerDiagnosticExtension.cs" />
     <Compile Include="Diagnostic\UDPMessageHandlerSemanticEventSource.cs" />
     <Compile Include="IPAddressValidationRule.cs" />
     <Compile Include="MessageHandlerFactory.cs" />


### PR DESCRIPTION
It addresses Networking - add consistent tracing infrastructure  #225.
There are not breaking changes hopefully. The tracing for `Networking.UDPMessageHandler` has been improved and can be used as an example for other add-ins. 

It should be considered to move common functionality to the library to promote re-usability.

I am going to accept this pr in a few days. If you need stable code clone or fork master right now.