### PR TITLE
UAReferenceContext - causes circular references #558

### DIFF
--- a/SemanticData/Tests/USNodeSetValidationUnitTestProject/AddressSpaceContextUnitTest.cs
+++ b/SemanticData/Tests/USNodeSetValidationUnitTestProject/AddressSpaceContextUnitTest.cs
@@ -128,8 +128,7 @@ namespace UAOOI.SemanticData.UANodeSetValidation
       asp.UTGetReferences(NodeId.Parse(newNodeSet.Items[0].NodeId), x => references.Add(x));
       Assert.AreEqual<int>(1, references.Count);
       Assert.AreEqual<ReferenceKindEnum>(ReferenceKindEnum.HasProperty, references[0].ReferenceKind);
-      //UAReferenceContext - causes circular references #558
-      Assert.IsTrue(references[0].IsSubtypeOf(ReferenceTypeIds.HasProperty));
+      Assert.AreEqual<ReferenceKindEnum>(ReferenceKindEnum.HasProperty, references[0].ReferenceKind);
       references.Clear();
       asp.UTGetReferences(NodeId.Parse(newNodeSet.Items[1].NodeId), x => references.Add(x));
       Assert.AreEqual<int>(2, references.Count);

--- a/SemanticData/UANodeSetValidation/UAReferenceContext.cs
+++ b/SemanticData/UANodeSetValidation/UAReferenceContext.cs
@@ -46,14 +46,6 @@ namespace UAOOI.SemanticData.UANodeSetValidation
 
     #region semantics
 
-    //TODO UAReferenceContext - causes circular references #558
-    internal bool IsSubtypeOf(NodeId referenceType)
-    {
-      List<IUANodeContext> inheritanceChain = new List<IUANodeContext>();
-      m_AddressSpace.GetBaseTypes(TypeNode, inheritanceChain);
-      return inheritanceChain.Where<IUANodeContext>(x => x.NodeIdContext == referenceType).Any<IUANodeContext>();
-    }
-
     /// <summary>
     /// Gets the kind of the reference.
     /// </summary>


### PR DESCRIPTION
- removed IsSubtypeOf - it is not longer used.
- UT :+1: